### PR TITLE
Added CommandService into container before hooking up the DiscordSock…

### DIFF
--- a/ScrubBot/Core/Bot.cs
+++ b/ScrubBot/Core/Bot.cs
@@ -43,10 +43,12 @@ namespace ScrubBot
             _commandService.AddModulesAsync(Assembly.GetEntryAssembly()).Wait();
             _commandService.Log += OnClientLog;
 
+            Container.Add(_commandService);
+
             HookEvents();
 
             Container.Add(_client);
-            Container.Add(_commandService);
+
             _prefixHandler = Container.Get<PrefixHandler>();
         }
 


### PR DESCRIPTION
…etClient events, which require a reference to said CommandService, fixes #37